### PR TITLE
fix: added url to base options for inline widget

### DIFF
--- a/src/runtime/components/CalendlyInlineWidget.vue
+++ b/src/runtime/components/CalendlyInlineWidget.vue
@@ -24,7 +24,7 @@
   import LoadingSpinner from "./LoadingSpinner.vue"
 
   const props = defineProps<{
-    url: CalendlyInlineWidgetOptions["url"]
+    url: string
     prefill?: CalendlyInlineWidgetOptions["prefill"]
     utm?: CalendlyInlineWidgetOptions["utm"]
     pageSettings?: CalendlyInlineWidgetOptions["pageSettings"]

--- a/src/runtime/types/index.d.ts
+++ b/src/runtime/types/index.d.ts
@@ -85,7 +85,15 @@ type PopupOptionsBase = {
   url: string
 }
 
-export type CalendlyInlineWidgetOptions = {
+type InlineOptionsBase = {
+  /**
+   * Calendly URL (Required)
+   * @description The URL of your Calendly event page.
+   */
+  url: string
+}
+
+export type CalendlyInlineWidgetOptions = InlineOptionsBase & {
   prefill?: Prefill
   utm?: Utm
   pageSettings?: PageSettings

--- a/src/runtime/types/index.d.ts
+++ b/src/runtime/types/index.d.ts
@@ -85,15 +85,7 @@ type PopupOptionsBase = {
   url: string
 }
 
-type InlineOptionsBase = {
-  /**
-   * Calendly URL (Required)
-   * @description The URL of your Calendly event page.
-   */
-  url: string
-}
-
-export type CalendlyInlineWidgetOptions = InlineOptionsBase & {
+export type CalendlyInlineWidgetOptions = {
   prefill?: Prefill
   utm?: Utm
   pageSettings?: PageSettings


### PR DESCRIPTION
Hi, we get type error `Property 'url' does not exist on type 'CalendlyInlineWidgetOptions' `when we're typechecking our app. I saw that the url prop was used on line 27 in CalendlyInlineWidget.vue and added it in the same fashion as you did for all the popups `"PopupOptionsBase"`