### PR TITLE
docs: use new `nuxi module add` command in installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,14 +27,7 @@
 1. Add `nuxt-calendly` dependency to your project
 
 ```bash
-# Using pnpm
-pnpm add -D nuxt-calendly
-
-# Using yarn
-yarn add --dev nuxt-calendly
-
-# Using npm
-npm install --save-dev nuxt-calendly
+npx nuxi@latest module add calendly
 ```
 
 2. Add `nuxt-calendly` to the `modules` section of `nuxt.config.ts`


### PR DESCRIPTION

This updates the documentation to use the [`nuxi module add` command](https://github.com/nuxt/cli/pull/197) which should simplify docs a bit and also improve user experience as there's no need to add to `nuxt.config` manually.

It's documented [here](https://nuxt.com/docs/api/commands/module#nuxi-module-add).

I may have missed a few spots in the documentation as I'm doing this across the modules ecosystem assisted by the power of regular expressions ✨, so I'd appreciate a review 🙏
