### PR TITLE
feature/add-page-resize-event-listener

### DIFF
--- a/src/runtime/composables/useCalendlyEventListener.ts
+++ b/src/runtime/composables/useCalendlyEventListener.ts
@@ -11,12 +11,13 @@ export enum CalendlyEvent {
   EVENT_TYPE_VIEWED = "calendly.event_type_viewed",
   DATE_AND_TIME_SELECTED = "calendly.date_and_time_selected",
   EVENT_SCHEDULED = "calendly.event_scheduled",
+  PAGE_HEIGHT = "calendly.page_height",
 }
 
 const EVENT_NAME = "message"
 
 export default function useCalendlyEventListener(eventHandlers: CalendlyEventHandlers) {
-  const { onDateAndTimeSelected, onEventScheduled, onEventTypeViewed, onProfilePageViewed } = eventHandlers || {}
+  const { onDateAndTimeSelected, onEventScheduled, onEventTypeViewed, onProfilePageViewed, onPageHeightResize } = eventHandlers || {}
   
   const onMessage = (e: MessageEvent) => {
     const eventName = e.data.event
@@ -29,6 +30,8 @@ export default function useCalendlyEventListener(eventHandlers: CalendlyEventHan
       onEventTypeViewed && onEventTypeViewed(e)
     } else if (eventName === CalendlyEvent.PROFILE_PAGE_VIEWED) {
       onProfilePageViewed && onProfilePageViewed(e)
+    } else if (eventName === CalendlyEvent.PAGE_HEIGHT) {
+      onPageHeightResize && onPageHeightResize(e);
     }
   }
 

--- a/src/runtime/types/index.d.ts
+++ b/src/runtime/types/index.d.ts
@@ -163,11 +163,23 @@ export type ProfilePageViewedEvent = MessageEvent<{
   payload: {}
 }>
 
+export type PageHeightResizeEvent = MessageEvent<{
+  event: CalendlyEvent.PAGE_HEIGHT;
+  payload: {
+    /**
+       * @description The height of the Calendly scheduling page in pixels.
+       * @example 1200px
+    */
+    height: string;
+  };
+}>;
+
 export type CalendlyEventHandlers = {
   onDateAndTimeSelected?: (e: DateAndTimeSelectedEvent) => any
   onEventScheduled?: (e: EventScheduledEvent) => any
   onEventTypeViewed?: (e: EventTypeViewedEvent) => any
   onProfilePageViewed?: (e: ProfilePageViewedEvent) => any
+  onPageHeightResize?: (e: PageHeightResizeEvent) => any;
 }
 
 // --- custom ---


### PR DESCRIPTION
## Description

Adds `onPageHeightResize` event to the `useCalendlyEventListener` hook.

:warning: The resize event currently only fires if the `embed_type` query parameter is set to `Inline`. Looking at the code, I don't think this value is ever set to `Popup`, but just wanted to call this out as it is currently not documented in Calendly's help center.



## Demo

https://www.loom.com/share/d8de24a7da8545f085dcf46943b58ee5?sid=f1330c32-3d1c-4f12-9e30-4fadb2cceefc