### PR TITLE
Update CalendlyPopupWidget.vue

### DIFF
--- a/src/runtime/components/CalendlyPopupWidget.vue
+++ b/src/runtime/components/CalendlyPopupWidget.vue
@@ -1,11 +1,11 @@
 <template>
   <!-- prettier-ignore -->
   <div
-    className="calendly-badge-widget"
+    class="calendly-badge-widget"
     @click="onClick"
   >
     <div
-      className="calendly-badge-content"
+      class="calendly-badge-content"
       :style="style"
     >
       {{ props.text || "Schedule time with me" }}


### PR DESCRIPTION
### Description of the Issue

The `className` attribute in the nested `<div>` elements within this template breaks the styling on the badge component. The root `className` is correctly converted to `class`, but the nested `className` remains unchanged, resulting in the class not being applied and the style breaking.

### Solution

Changing both instances of `className` to `class` successfully resolves the issue and conforms to the official Nuxt documentation.

### Related Issue

This issue is related to a broader discussion in the Nuxt community:
- [Nuxt Discussion: Nested children `className` not rendered into `class` when refreshing in SSR mode #24548](https://github.com/nuxt/nuxt/discussions/24548)

### Documentation

For more information on the correct syntax, please refer to the official Vue.js documentation:
- [Vue.js Guide: Class and Style Bindings](https://vuejs.org/guide/essentials/class-and-style)

---

### Additional Notes

Big thanks to Fabian for building this time-saving module!
