### PR TITLE
Update CalendlyPopupButton.vue

### DIFF
--- a/src/runtime/components/CalendlyPopupButton.vue
+++ b/src/runtime/components/CalendlyPopupButton.vue
@@ -5,6 +5,7 @@
     @click="onClick"
   >
     {{ props.text || 'Schedule time with me' }}
+    <slot />
   </button>
   <PopupModal
     v-bind="props"


### PR DESCRIPTION
### Enhancement: Added Slot for Increased Flexibility

![image](https://github.com/user-attachments/assets/f0ffeb44-474d-4658-bd9f-c1ee9266c6dc)

This update introduces a slot to the `CalendlyPopupButton` component, enhancing its flexibility. For example, you can now pass an icon component directly into the button:

```vue
<CalendlyPopupButton
  v-bind="options"
  :root-element="rootElement"
>
  <UIcon
    name="i-heroicons-arrow-top-right-on-square-20-solid"
    class="ml-1 w-5 h-5 pointer-events-none align-text-bottom"
  />
</CalendlyPopupButton>
